### PR TITLE
Ts client hotfix

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2160,216 +2160,126 @@
         "protobufjs": "^6.8.8"
       }
     },
-    "node_modules/@cosmjs/json-rpc": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.29.5.tgz",
-      "integrity": "sha512-C78+X06l+r9xwdM1yFWIpGl03LhB9NdM1xvZpQHwgCOl0Ir/WV8pw48y3Ez2awAoUBRfTeejPe4KvrE6NoIi/w==",
+    "node_modules/@cosmjs/amino": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.30.0.tgz",
+      "integrity": "sha512-DFPu0dALghQj7A9b8SHnrpNiMsGi4lEs2ZM7XvO/baYgktn8iS5P9LQXmDch5UhKkjJy+uz5aAMD9iFlK6opCQ==",
       "dependencies": {
-        "@cosmjs/stream": "^0.29.5",
-        "xstream": "^11.14.0"
+        "@cosmjs/crypto": "^0.30.0",
+        "@cosmjs/encoding": "^0.30.0",
+        "@cosmjs/math": "^0.30.0",
+        "@cosmjs/utils": "^0.30.0"
       }
     },
-    "node_modules/@cosmjs/proto-signing": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.29.5.tgz",
-      "integrity": "sha512-QRrS7CiKaoETdgIqvi/7JC2qCwCR7lnWaUsTzh/XfRy3McLkEd+cXbKAW3cygykv7IN0VAEIhZd2lyIfT8KwNA==",
+    "node_modules/@cosmjs/crypto": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.30.0.tgz",
+      "integrity": "sha512-qjR5vG7G2Hyc1oE5W1vm73Mf7723ooQXWvUBj5QTsNHI4EFJ52jCHhHb7Ynuh6WmBDpfisCios7AWTpA2PSmAQ==",
       "dependencies": {
-        "@cosmjs/amino": "^0.29.5",
-        "@cosmjs/crypto": "^0.29.5",
-        "@cosmjs/encoding": "^0.29.5",
-        "@cosmjs/math": "^0.29.5",
-        "@cosmjs/utils": "^0.29.5",
-        "cosmjs-types": "^0.5.2",
-        "long": "^4.0.0"
-      }
-    },
-    "node_modules/@cosmjs/proto-signing/node_modules/@cosmjs/amino": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.29.5.tgz",
-      "integrity": "sha512-Qo8jpC0BiziTSUqpkNatBcwtKNhCovUnFul9SlT/74JUCdLYaeG5hxr3q1cssQt++l4LvlcpF+OUXL48XjNjLw==",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.29.5",
-        "@cosmjs/encoding": "^0.29.5",
-        "@cosmjs/math": "^0.29.5",
-        "@cosmjs/utils": "^0.29.5"
-      }
-    },
-    "node_modules/@cosmjs/proto-signing/node_modules/@cosmjs/crypto": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.29.5.tgz",
-      "integrity": "sha512-2bKkaLGictaNL0UipQCL6C1afaisv6k8Wr/GCLx9FqiyFkh9ZgRHDyetD64ZsjnWV/N/D44s/esI+k6oPREaiQ==",
-      "dependencies": {
-        "@cosmjs/encoding": "^0.29.5",
-        "@cosmjs/math": "^0.29.5",
-        "@cosmjs/utils": "^0.29.5",
+        "@cosmjs/encoding": "^0.30.0",
+        "@cosmjs/math": "^0.30.0",
+        "@cosmjs/utils": "^0.30.0",
         "@noble/hashes": "^1",
         "bn.js": "^5.2.0",
         "elliptic": "^6.5.4",
         "libsodium-wrappers": "^0.7.6"
       }
     },
-    "node_modules/@cosmjs/proto-signing/node_modules/@cosmjs/encoding": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.29.5.tgz",
-      "integrity": "sha512-G4rGl/Jg4dMCw5u6PEZHZcoHnUBlukZODHbm/wcL4Uu91fkn5jVo5cXXZcvs4VCkArVGrEj/52eUgTZCmOBGWQ==",
+    "node_modules/@cosmjs/encoding": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.30.0.tgz",
+      "integrity": "sha512-b/ZAyAEaUstk6ctcF44ufEWKVMv6S732jUxTz3eGmGCKbZhlVPmk5P2Pc4IHl+IJPtCBoeCLG8KcskVtkNoPvQ==",
       "dependencies": {
         "base64-js": "^1.3.0",
         "bech32": "^1.1.4",
         "readonly-date": "^1.0.0"
       }
     },
-    "node_modules/@cosmjs/proto-signing/node_modules/@cosmjs/math": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.29.5.tgz",
-      "integrity": "sha512-2GjKcv+A9f86MAWYLUkjhw1/WpRl2R1BTb3m9qPG7lzMA7ioYff9jY5SPCfafKdxM4TIQGxXQlYGewQL16O68Q==",
+    "node_modules/@cosmjs/json-rpc": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.30.0.tgz",
+      "integrity": "sha512-zTPM+mPzq67wI/cphe8I3/4gsIe017c4l/BSiFD7jqjsOKyjhuKzNLuABPGNNRnPo6k9I1Lgb/Z/QPWp9rXuMA==",
+      "dependencies": {
+        "@cosmjs/stream": "^0.30.0",
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@cosmjs/math": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.30.0.tgz",
+      "integrity": "sha512-RfrRJe/p7Eu2/ulFQT9IUXA6CL43klcTJu+DRu/iI91LFf64L8Ycid5EQKkEUk4mpI+D2WGx5N0FT99h7pYuCw==",
       "dependencies": {
         "bn.js": "^5.2.0"
       }
     },
-    "node_modules/@cosmjs/proto-signing/node_modules/@cosmjs/utils": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.29.5.tgz",
-      "integrity": "sha512-m7h+RXDUxOzEOGt4P+3OVPX7PuakZT3GBmaM/Y2u+abN3xZkziykD/NvedYFvvCCdQo714XcGl33bwifS9FZPQ=="
+    "node_modules/@cosmjs/proto-signing": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.30.0.tgz",
+      "integrity": "sha512-+AKJa8xomn/qt73mu98yRQdiqb8wfrmwZGOCsUNRMSs5GIj8ltGNwTwElKY2VjK+O9buG7NSyVQBEGycC5Nj0A==",
+      "dependencies": {
+        "@cosmjs/amino": "^0.30.0",
+        "@cosmjs/crypto": "^0.30.0",
+        "@cosmjs/encoding": "^0.30.0",
+        "@cosmjs/math": "^0.30.0",
+        "@cosmjs/utils": "^0.30.0",
+        "cosmjs-types": "^0.7.1",
+        "long": "^4.0.0"
+      }
     },
     "node_modules/@cosmjs/socket": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.29.5.tgz",
-      "integrity": "sha512-5VYDupIWbIXq3ftPV1LkS5Ya/T7Ol/AzWVhNxZ79hPe/mBfv1bGau/LqIYOm2zxGlgm9hBHOTmWGqNYDwr9LNQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.30.0.tgz",
+      "integrity": "sha512-zEheZY292C0ec5jx1egOTVmDjBqHMciXpNNDAyo8QpZkVNq9Q4XGKvPOH67jSRQUTiy9NxKXW1Tqr84kqZ3C3A==",
       "dependencies": {
-        "@cosmjs/stream": "^0.29.5",
+        "@cosmjs/stream": "^0.30.0",
         "isomorphic-ws": "^4.0.1",
         "ws": "^7",
         "xstream": "^11.14.0"
       }
     },
     "node_modules/@cosmjs/stargate": {
-      "version": "0.29.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.29.4.tgz",
-      "integrity": "sha512-MEzBkOhYX0tdGgJg4mxFDjf7NMJYKNtXHX0Fu4HVACdBrxLlStf630KodmzPFlLOHfiz3CB/mqj3TobZZz8mTw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.30.0.tgz",
+      "integrity": "sha512-BrE1iV7M0/oBSTM5doDS+qX4Na1sVtSYMQsGUV3wde49gVttVsoHTNufk4KESQ7lfGemSwgOMsgoKBs/M8TnlA==",
       "dependencies": {
         "@confio/ics23": "^0.6.8",
-        "@cosmjs/amino": "^0.29.4",
-        "@cosmjs/encoding": "^0.29.4",
-        "@cosmjs/math": "^0.29.4",
-        "@cosmjs/proto-signing": "^0.29.4",
-        "@cosmjs/stream": "^0.29.4",
-        "@cosmjs/tendermint-rpc": "^0.29.4",
-        "@cosmjs/utils": "^0.29.4",
-        "cosmjs-types": "^0.5.2",
+        "@cosmjs/amino": "^0.30.0",
+        "@cosmjs/encoding": "^0.30.0",
+        "@cosmjs/math": "^0.30.0",
+        "@cosmjs/proto-signing": "^0.30.0",
+        "@cosmjs/stream": "^0.30.0",
+        "@cosmjs/tendermint-rpc": "^0.30.0",
+        "@cosmjs/utils": "^0.30.0",
+        "cosmjs-types": "^0.7.1",
         "long": "^4.0.0",
         "protobufjs": "~6.11.3",
         "xstream": "^11.14.0"
       }
     },
-    "node_modules/@cosmjs/stargate/node_modules/@cosmjs/amino": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.29.5.tgz",
-      "integrity": "sha512-Qo8jpC0BiziTSUqpkNatBcwtKNhCovUnFul9SlT/74JUCdLYaeG5hxr3q1cssQt++l4LvlcpF+OUXL48XjNjLw==",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.29.5",
-        "@cosmjs/encoding": "^0.29.5",
-        "@cosmjs/math": "^0.29.5",
-        "@cosmjs/utils": "^0.29.5"
-      }
-    },
-    "node_modules/@cosmjs/stargate/node_modules/@cosmjs/crypto": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.29.5.tgz",
-      "integrity": "sha512-2bKkaLGictaNL0UipQCL6C1afaisv6k8Wr/GCLx9FqiyFkh9ZgRHDyetD64ZsjnWV/N/D44s/esI+k6oPREaiQ==",
-      "dependencies": {
-        "@cosmjs/encoding": "^0.29.5",
-        "@cosmjs/math": "^0.29.5",
-        "@cosmjs/utils": "^0.29.5",
-        "@noble/hashes": "^1",
-        "bn.js": "^5.2.0",
-        "elliptic": "^6.5.4",
-        "libsodium-wrappers": "^0.7.6"
-      }
-    },
-    "node_modules/@cosmjs/stargate/node_modules/@cosmjs/encoding": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.29.5.tgz",
-      "integrity": "sha512-G4rGl/Jg4dMCw5u6PEZHZcoHnUBlukZODHbm/wcL4Uu91fkn5jVo5cXXZcvs4VCkArVGrEj/52eUgTZCmOBGWQ==",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "bech32": "^1.1.4",
-        "readonly-date": "^1.0.0"
-      }
-    },
-    "node_modules/@cosmjs/stargate/node_modules/@cosmjs/math": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.29.5.tgz",
-      "integrity": "sha512-2GjKcv+A9f86MAWYLUkjhw1/WpRl2R1BTb3m9qPG7lzMA7ioYff9jY5SPCfafKdxM4TIQGxXQlYGewQL16O68Q==",
-      "dependencies": {
-        "bn.js": "^5.2.0"
-      }
-    },
-    "node_modules/@cosmjs/stargate/node_modules/@cosmjs/utils": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.29.5.tgz",
-      "integrity": "sha512-m7h+RXDUxOzEOGt4P+3OVPX7PuakZT3GBmaM/Y2u+abN3xZkziykD/NvedYFvvCCdQo714XcGl33bwifS9FZPQ=="
-    },
     "node_modules/@cosmjs/stream": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.29.5.tgz",
-      "integrity": "sha512-TToTDWyH1p05GBtF0Y8jFw2C+4783ueDCmDyxOMM6EU82IqpmIbfwcdMOCAm0JhnyMh+ocdebbFvnX/sGKzRAA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.30.0.tgz",
+      "integrity": "sha512-MkspvIDkZGZQcT8AOkCbG3vXzYED5jLJlki+FuNDWGOVCZVv89IF/v59f+Hg5pJUShRmGZ1cWfmpzYkGHxdEog==",
       "dependencies": {
         "xstream": "^11.14.0"
       }
     },
     "node_modules/@cosmjs/tendermint-rpc": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.29.5.tgz",
-      "integrity": "sha512-ar80twieuAxsy0x2za/aO3kBr2DFPAXDmk2ikDbmkda+qqfXgl35l9CVAAjKRqd9d+cRvbQyb5M4wy6XQpEV6w==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.30.0.tgz",
+      "integrity": "sha512-QpNXwxfCPTHXrfq/LzXvwRxDjTV0R16kPISJ00zu3zSTtANCnBMZiNNFszrCdZKw81fNKo8/Rf2T0gCNvWfGog==",
       "dependencies": {
-        "@cosmjs/crypto": "^0.29.5",
-        "@cosmjs/encoding": "^0.29.5",
-        "@cosmjs/json-rpc": "^0.29.5",
-        "@cosmjs/math": "^0.29.5",
-        "@cosmjs/socket": "^0.29.5",
-        "@cosmjs/stream": "^0.29.5",
-        "@cosmjs/utils": "^0.29.5",
+        "@cosmjs/crypto": "^0.30.0",
+        "@cosmjs/encoding": "^0.30.0",
+        "@cosmjs/json-rpc": "^0.30.0",
+        "@cosmjs/math": "^0.30.0",
+        "@cosmjs/socket": "^0.30.0",
+        "@cosmjs/stream": "^0.30.0",
+        "@cosmjs/utils": "^0.30.0",
         "axios": "^0.21.2",
         "readonly-date": "^1.0.0",
         "xstream": "^11.14.0"
       }
-    },
-    "node_modules/@cosmjs/tendermint-rpc/node_modules/@cosmjs/crypto": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.29.5.tgz",
-      "integrity": "sha512-2bKkaLGictaNL0UipQCL6C1afaisv6k8Wr/GCLx9FqiyFkh9ZgRHDyetD64ZsjnWV/N/D44s/esI+k6oPREaiQ==",
-      "dependencies": {
-        "@cosmjs/encoding": "^0.29.5",
-        "@cosmjs/math": "^0.29.5",
-        "@cosmjs/utils": "^0.29.5",
-        "@noble/hashes": "^1",
-        "bn.js": "^5.2.0",
-        "elliptic": "^6.5.4",
-        "libsodium-wrappers": "^0.7.6"
-      }
-    },
-    "node_modules/@cosmjs/tendermint-rpc/node_modules/@cosmjs/encoding": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.29.5.tgz",
-      "integrity": "sha512-G4rGl/Jg4dMCw5u6PEZHZcoHnUBlukZODHbm/wcL4Uu91fkn5jVo5cXXZcvs4VCkArVGrEj/52eUgTZCmOBGWQ==",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "bech32": "^1.1.4",
-        "readonly-date": "^1.0.0"
-      }
-    },
-    "node_modules/@cosmjs/tendermint-rpc/node_modules/@cosmjs/math": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.29.5.tgz",
-      "integrity": "sha512-2GjKcv+A9f86MAWYLUkjhw1/WpRl2R1BTb3m9qPG7lzMA7ioYff9jY5SPCfafKdxM4TIQGxXQlYGewQL16O68Q==",
-      "dependencies": {
-        "bn.js": "^5.2.0"
-      }
-    },
-    "node_modules/@cosmjs/tendermint-rpc/node_modules/@cosmjs/utils": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.29.5.tgz",
-      "integrity": "sha512-m7h+RXDUxOzEOGt4P+3OVPX7PuakZT3GBmaM/Y2u+abN3xZkziykD/NvedYFvvCCdQo714XcGl33bwifS9FZPQ=="
     },
     "node_modules/@cosmjs/tendermint-rpc/node_modules/axios": {
       "version": "0.21.4",
@@ -2378,6 +2288,11 @@
       "dependencies": {
         "follow-redirects": "^1.14.0"
       }
+    },
+    "node_modules/@cosmjs/utils": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.30.0.tgz",
+      "integrity": "sha512-A0YaBUlAojyuygqXOjDZa6YT/NOeScq08CqMD5VfU0COlzJS2DKN0z0jfYDt3t3VEXT5ZV8OaLbN3jHah1cSlA=="
     },
     "node_modules/@cosmwasm/ts-codegen": {
       "version": "0.21.1",
@@ -5192,6 +5107,24 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@osmonauts/lcd": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@osmonauts/lcd/-/lcd-0.10.0.tgz",
+      "integrity": "sha512-PzmXk9x9MHyLn2fUztpAqWqvDmMiEJaQv/JcAoAOE8VdHrD9Hf/KWnE1RZtamuS2ngQRqvQPD0xotCGXW7eTxA==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "axios": "0.27.2"
+      }
+    },
+    "node_modules/@osmonauts/lcd/node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
     "node_modules/@osmonauts/proto-parser": {
       "version": "0.33.0",
       "resolved": "https://registry.npmjs.org/@osmonauts/proto-parser/-/proto-parser-0.33.0.tgz",
@@ -7029,8 +6962,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -7959,7 +7891,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -8225,9 +8156,9 @@
       }
     },
     "node_modules/cosmjs-types": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.5.2.tgz",
-      "integrity": "sha512-zxCtIJj8v3Di7s39uN4LNcN3HIE1z0B9Z0SPE8ZNQR0oSzsuSe1ACgxoFkvhkS7WBasCAFcglS11G2hyfd5tPg==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.7.1.tgz",
+      "integrity": "sha512-qP89SGwi6YpvMTrM9CPzTfZ0JPNlXzgimqMLsa/ZjzW+L6MC8TCr6XmoWtFOT6GSfefvJLwFWq7YCtL456Bdzg==",
       "dependencies": {
         "long": "^4.0.0",
         "protobufjs": "~6.11.2"
@@ -8509,7 +8440,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -9803,7 +9733,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -12945,16 +12874,16 @@
       }
     },
     "node_modules/libsodium": {
-      "version": "0.7.10",
-      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.10.tgz",
-      "integrity": "sha512-eY+z7hDrDKxkAK+QKZVNv92A5KYkxfvIshtBJkmg5TSiCnYqZP3i9OO9whE79Pwgm4jGaoHgkM4ao/b9Cyu4zQ=="
+      "version": "0.7.11",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.11.tgz",
+      "integrity": "sha512-WPfJ7sS53I2s4iM58QxY3Inb83/6mjlYgcmZs7DJsvDlnmVUwNinBCi5vBT43P6bHRy01O4zsMU2CoVR6xJ40A=="
     },
     "node_modules/libsodium-wrappers": {
-      "version": "0.7.10",
-      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.10.tgz",
-      "integrity": "sha512-pO3F1Q9NPLB/MWIhehim42b/Fwb30JNScCNh8TcQ/kIc+qGLQch8ag8wb0keK3EP5kbGakk1H8Wwo7v+36rNQg==",
+      "version": "0.7.11",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.11.tgz",
+      "integrity": "sha512-SrcLtXj7BM19vUKtQuyQKiQCRJPgbpauzl3s0rSwD+60wtHqSUuqcoawlMDheCJga85nKOQwxNYQxf/CKAvs6Q==",
       "dependencies": {
-        "libsodium": "^0.7.0"
+        "libsodium": "^0.7.11"
       }
     },
     "node_modules/lilconfig": {
@@ -13436,7 +13365,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -13445,7 +13373,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -16060,6 +15987,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
     "node_modules/resolve": {
       "version": "1.22.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -17172,6 +17105,150 @@
         "node": ">=12"
       }
     },
+    "node_modules/tsc-silent": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tsc-silent/-/tsc-silent-1.2.2.tgz",
+      "integrity": "sha512-XeNoMlREutyMotsQX7EijrgxXeyLscHUOV2W1goCZlEGvLH/7eFQ1snlPQf8cdQSdABqWEfvap0ab7s7FeCMrw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "10.12.7",
+        "yargs": "12 - 15"
+      },
+      "bin": {
+        "tsc-silent": "bin/tsc-silent"
+      },
+      "engines": {
+        "npm": ">=5"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.9",
+        "yargs": "12 - 15"
+      }
+    },
+    "node_modules/tsc-silent/node_modules/@types/node": {
+      "version": "10.12.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.7.tgz",
+      "integrity": "sha512-Zh5Z4kACfbeE8aAOYh9mqotRxaZMro8MbBQtR8vEXOMiZo2rGEh2LayJijKdlu48YnS6y2EFU/oo2NCe5P6jGw==",
+      "dev": true
+    },
+    "node_modules/tsc-silent/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/tsc-silent/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tsc-silent/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tsc-silent/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tsc-silent/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tsc-silent/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tsc-silent/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true
+    },
+    "node_modules/tsc-silent/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tsc-silent/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.1.2.tgz",
@@ -17948,6 +18025,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
+      "dev": true
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
@@ -18328,10 +18411,11 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@babel/runtime": "^7.19.4",
-        "@cosmjs/amino": "0.29.4",
-        "@cosmjs/proto-signing": "0.29.4",
-        "@cosmjs/stargate": "0.29.4",
-        "@cosmjs/tendermint-rpc": "^0.29.4",
+        "@cosmjs/amino": "0.30.0",
+        "@cosmjs/proto-signing": "0.30.0",
+        "@cosmjs/stargate": "0.30.0",
+        "@cosmjs/tendermint-rpc": "^0.30.0",
+        "@osmonauts/lcd": "^0.10.0",
         "protobufjs": "^6.11.2"
       },
       "devDependencies": {
@@ -18367,75 +18451,9 @@
         "regenerator-runtime": "^0.13.7",
         "rimraf": "^3.0.2",
         "ts-jest": "^29.0.3",
+        "tsc-silent": "^1.2.2",
         "typescript": "^4.8.4"
       }
-    },
-    "ts-client/node_modules/@cosmjs/amino": {
-      "version": "0.29.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.29.4.tgz",
-      "integrity": "sha512-FBjaJ4oUKFtH34O7XjUk370x8sF7EbXD29miXrm0Rl5GEtEORJgQwutXQllHo5gBkpOxC+ZQ40CibXhPzH7G7A==",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.29.4",
-        "@cosmjs/encoding": "^0.29.4",
-        "@cosmjs/math": "^0.29.4",
-        "@cosmjs/utils": "^0.29.4"
-      }
-    },
-    "ts-client/node_modules/@cosmjs/crypto": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.29.5.tgz",
-      "integrity": "sha512-2bKkaLGictaNL0UipQCL6C1afaisv6k8Wr/GCLx9FqiyFkh9ZgRHDyetD64ZsjnWV/N/D44s/esI+k6oPREaiQ==",
-      "dependencies": {
-        "@cosmjs/encoding": "^0.29.5",
-        "@cosmjs/math": "^0.29.5",
-        "@cosmjs/utils": "^0.29.5",
-        "@noble/hashes": "^1",
-        "bn.js": "^5.2.0",
-        "elliptic": "^6.5.4",
-        "libsodium-wrappers": "^0.7.6"
-      }
-    },
-    "ts-client/node_modules/@cosmjs/encoding": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.29.5.tgz",
-      "integrity": "sha512-G4rGl/Jg4dMCw5u6PEZHZcoHnUBlukZODHbm/wcL4Uu91fkn5jVo5cXXZcvs4VCkArVGrEj/52eUgTZCmOBGWQ==",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "bech32": "^1.1.4",
-        "readonly-date": "^1.0.0"
-      }
-    },
-    "ts-client/node_modules/@cosmjs/math": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.29.5.tgz",
-      "integrity": "sha512-2GjKcv+A9f86MAWYLUkjhw1/WpRl2R1BTb3m9qPG7lzMA7ioYff9jY5SPCfafKdxM4TIQGxXQlYGewQL16O68Q==",
-      "dependencies": {
-        "bn.js": "^5.2.0"
-      }
-    },
-    "ts-client/node_modules/@cosmjs/proto-signing": {
-      "version": "0.29.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.29.4.tgz",
-      "integrity": "sha512-GdLOhMd54LZgG+kHf7uAWGYDT628yVhXPMWaG/1i3f3Kq4VsZgFBwJhhziM5kWblmFjBOhooGRwLrBnOxMusCg==",
-      "dependencies": {
-        "@cosmjs/amino": "^0.29.4",
-        "@cosmjs/crypto": "^0.29.4",
-        "@cosmjs/encoding": "^0.29.4",
-        "@cosmjs/math": "^0.29.4",
-        "@cosmjs/utils": "^0.29.4",
-        "cosmjs-types": "^0.5.2",
-        "long": "^4.0.0"
-      }
-    },
-    "ts-client/node_modules/@cosmjs/proto-signing/node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-    },
-    "ts-client/node_modules/@cosmjs/utils": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.29.5.tgz",
-      "integrity": "sha512-m7h+RXDUxOzEOGt4P+3OVPX7PuakZT3GBmaM/Y2u+abN3xZkziykD/NvedYFvvCCdQo714XcGl33bwifS9FZPQ=="
     },
     "ts-client/node_modules/@humanwhocodes/config-array": {
       "version": "0.10.7",
@@ -20064,221 +20082,127 @@
         "protobufjs": "^6.8.8"
       }
     },
-    "@cosmjs/json-rpc": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.29.5.tgz",
-      "integrity": "sha512-C78+X06l+r9xwdM1yFWIpGl03LhB9NdM1xvZpQHwgCOl0Ir/WV8pw48y3Ez2awAoUBRfTeejPe4KvrE6NoIi/w==",
+    "@cosmjs/amino": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.30.0.tgz",
+      "integrity": "sha512-DFPu0dALghQj7A9b8SHnrpNiMsGi4lEs2ZM7XvO/baYgktn8iS5P9LQXmDch5UhKkjJy+uz5aAMD9iFlK6opCQ==",
       "requires": {
-        "@cosmjs/stream": "^0.29.5",
+        "@cosmjs/crypto": "^0.30.0",
+        "@cosmjs/encoding": "^0.30.0",
+        "@cosmjs/math": "^0.30.0",
+        "@cosmjs/utils": "^0.30.0"
+      }
+    },
+    "@cosmjs/crypto": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.30.0.tgz",
+      "integrity": "sha512-qjR5vG7G2Hyc1oE5W1vm73Mf7723ooQXWvUBj5QTsNHI4EFJ52jCHhHb7Ynuh6WmBDpfisCios7AWTpA2PSmAQ==",
+      "requires": {
+        "@cosmjs/encoding": "^0.30.0",
+        "@cosmjs/math": "^0.30.0",
+        "@cosmjs/utils": "^0.30.0",
+        "@noble/hashes": "^1",
+        "bn.js": "^5.2.0",
+        "elliptic": "^6.5.4",
+        "libsodium-wrappers": "^0.7.6"
+      }
+    },
+    "@cosmjs/encoding": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.30.0.tgz",
+      "integrity": "sha512-b/ZAyAEaUstk6ctcF44ufEWKVMv6S732jUxTz3eGmGCKbZhlVPmk5P2Pc4IHl+IJPtCBoeCLG8KcskVtkNoPvQ==",
+      "requires": {
+        "base64-js": "^1.3.0",
+        "bech32": "^1.1.4",
+        "readonly-date": "^1.0.0"
+      }
+    },
+    "@cosmjs/json-rpc": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.30.0.tgz",
+      "integrity": "sha512-zTPM+mPzq67wI/cphe8I3/4gsIe017c4l/BSiFD7jqjsOKyjhuKzNLuABPGNNRnPo6k9I1Lgb/Z/QPWp9rXuMA==",
+      "requires": {
+        "@cosmjs/stream": "^0.30.0",
         "xstream": "^11.14.0"
       }
     },
-    "@cosmjs/proto-signing": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.29.5.tgz",
-      "integrity": "sha512-QRrS7CiKaoETdgIqvi/7JC2qCwCR7lnWaUsTzh/XfRy3McLkEd+cXbKAW3cygykv7IN0VAEIhZd2lyIfT8KwNA==",
+    "@cosmjs/math": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.30.0.tgz",
+      "integrity": "sha512-RfrRJe/p7Eu2/ulFQT9IUXA6CL43klcTJu+DRu/iI91LFf64L8Ycid5EQKkEUk4mpI+D2WGx5N0FT99h7pYuCw==",
       "requires": {
-        "@cosmjs/amino": "^0.29.5",
-        "@cosmjs/crypto": "^0.29.5",
-        "@cosmjs/encoding": "^0.29.5",
-        "@cosmjs/math": "^0.29.5",
-        "@cosmjs/utils": "^0.29.5",
-        "cosmjs-types": "^0.5.2",
+        "bn.js": "^5.2.0"
+      }
+    },
+    "@cosmjs/proto-signing": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.30.0.tgz",
+      "integrity": "sha512-+AKJa8xomn/qt73mu98yRQdiqb8wfrmwZGOCsUNRMSs5GIj8ltGNwTwElKY2VjK+O9buG7NSyVQBEGycC5Nj0A==",
+      "requires": {
+        "@cosmjs/amino": "^0.30.0",
+        "@cosmjs/crypto": "^0.30.0",
+        "@cosmjs/encoding": "^0.30.0",
+        "@cosmjs/math": "^0.30.0",
+        "@cosmjs/utils": "^0.30.0",
+        "cosmjs-types": "^0.7.1",
         "long": "^4.0.0"
-      },
-      "dependencies": {
-        "@cosmjs/amino": {
-          "version": "0.29.5",
-          "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.29.5.tgz",
-          "integrity": "sha512-Qo8jpC0BiziTSUqpkNatBcwtKNhCovUnFul9SlT/74JUCdLYaeG5hxr3q1cssQt++l4LvlcpF+OUXL48XjNjLw==",
-          "requires": {
-            "@cosmjs/crypto": "^0.29.5",
-            "@cosmjs/encoding": "^0.29.5",
-            "@cosmjs/math": "^0.29.5",
-            "@cosmjs/utils": "^0.29.5"
-          }
-        },
-        "@cosmjs/crypto": {
-          "version": "0.29.5",
-          "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.29.5.tgz",
-          "integrity": "sha512-2bKkaLGictaNL0UipQCL6C1afaisv6k8Wr/GCLx9FqiyFkh9ZgRHDyetD64ZsjnWV/N/D44s/esI+k6oPREaiQ==",
-          "requires": {
-            "@cosmjs/encoding": "^0.29.5",
-            "@cosmjs/math": "^0.29.5",
-            "@cosmjs/utils": "^0.29.5",
-            "@noble/hashes": "^1",
-            "bn.js": "^5.2.0",
-            "elliptic": "^6.5.4",
-            "libsodium-wrappers": "^0.7.6"
-          }
-        },
-        "@cosmjs/encoding": {
-          "version": "0.29.5",
-          "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.29.5.tgz",
-          "integrity": "sha512-G4rGl/Jg4dMCw5u6PEZHZcoHnUBlukZODHbm/wcL4Uu91fkn5jVo5cXXZcvs4VCkArVGrEj/52eUgTZCmOBGWQ==",
-          "requires": {
-            "base64-js": "^1.3.0",
-            "bech32": "^1.1.4",
-            "readonly-date": "^1.0.0"
-          }
-        },
-        "@cosmjs/math": {
-          "version": "0.29.5",
-          "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.29.5.tgz",
-          "integrity": "sha512-2GjKcv+A9f86MAWYLUkjhw1/WpRl2R1BTb3m9qPG7lzMA7ioYff9jY5SPCfafKdxM4TIQGxXQlYGewQL16O68Q==",
-          "requires": {
-            "bn.js": "^5.2.0"
-          }
-        },
-        "@cosmjs/utils": {
-          "version": "0.29.5",
-          "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.29.5.tgz",
-          "integrity": "sha512-m7h+RXDUxOzEOGt4P+3OVPX7PuakZT3GBmaM/Y2u+abN3xZkziykD/NvedYFvvCCdQo714XcGl33bwifS9FZPQ=="
-        }
       }
     },
     "@cosmjs/socket": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.29.5.tgz",
-      "integrity": "sha512-5VYDupIWbIXq3ftPV1LkS5Ya/T7Ol/AzWVhNxZ79hPe/mBfv1bGau/LqIYOm2zxGlgm9hBHOTmWGqNYDwr9LNQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.30.0.tgz",
+      "integrity": "sha512-zEheZY292C0ec5jx1egOTVmDjBqHMciXpNNDAyo8QpZkVNq9Q4XGKvPOH67jSRQUTiy9NxKXW1Tqr84kqZ3C3A==",
       "requires": {
-        "@cosmjs/stream": "^0.29.5",
+        "@cosmjs/stream": "^0.30.0",
         "isomorphic-ws": "^4.0.1",
         "ws": "^7",
         "xstream": "^11.14.0"
       }
     },
     "@cosmjs/stargate": {
-      "version": "0.29.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.29.4.tgz",
-      "integrity": "sha512-MEzBkOhYX0tdGgJg4mxFDjf7NMJYKNtXHX0Fu4HVACdBrxLlStf630KodmzPFlLOHfiz3CB/mqj3TobZZz8mTw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.30.0.tgz",
+      "integrity": "sha512-BrE1iV7M0/oBSTM5doDS+qX4Na1sVtSYMQsGUV3wde49gVttVsoHTNufk4KESQ7lfGemSwgOMsgoKBs/M8TnlA==",
       "requires": {
         "@confio/ics23": "^0.6.8",
-        "@cosmjs/amino": "^0.29.4",
-        "@cosmjs/encoding": "^0.29.4",
-        "@cosmjs/math": "^0.29.4",
-        "@cosmjs/proto-signing": "^0.29.4",
-        "@cosmjs/stream": "^0.29.4",
-        "@cosmjs/tendermint-rpc": "^0.29.4",
-        "@cosmjs/utils": "^0.29.4",
-        "cosmjs-types": "^0.5.2",
+        "@cosmjs/amino": "^0.30.0",
+        "@cosmjs/encoding": "^0.30.0",
+        "@cosmjs/math": "^0.30.0",
+        "@cosmjs/proto-signing": "^0.30.0",
+        "@cosmjs/stream": "^0.30.0",
+        "@cosmjs/tendermint-rpc": "^0.30.0",
+        "@cosmjs/utils": "^0.30.0",
+        "cosmjs-types": "^0.7.1",
         "long": "^4.0.0",
         "protobufjs": "~6.11.3",
         "xstream": "^11.14.0"
-      },
-      "dependencies": {
-        "@cosmjs/amino": {
-          "version": "0.29.5",
-          "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.29.5.tgz",
-          "integrity": "sha512-Qo8jpC0BiziTSUqpkNatBcwtKNhCovUnFul9SlT/74JUCdLYaeG5hxr3q1cssQt++l4LvlcpF+OUXL48XjNjLw==",
-          "requires": {
-            "@cosmjs/crypto": "^0.29.5",
-            "@cosmjs/encoding": "^0.29.5",
-            "@cosmjs/math": "^0.29.5",
-            "@cosmjs/utils": "^0.29.5"
-          }
-        },
-        "@cosmjs/crypto": {
-          "version": "0.29.5",
-          "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.29.5.tgz",
-          "integrity": "sha512-2bKkaLGictaNL0UipQCL6C1afaisv6k8Wr/GCLx9FqiyFkh9ZgRHDyetD64ZsjnWV/N/D44s/esI+k6oPREaiQ==",
-          "requires": {
-            "@cosmjs/encoding": "^0.29.5",
-            "@cosmjs/math": "^0.29.5",
-            "@cosmjs/utils": "^0.29.5",
-            "@noble/hashes": "^1",
-            "bn.js": "^5.2.0",
-            "elliptic": "^6.5.4",
-            "libsodium-wrappers": "^0.7.6"
-          }
-        },
-        "@cosmjs/encoding": {
-          "version": "0.29.5",
-          "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.29.5.tgz",
-          "integrity": "sha512-G4rGl/Jg4dMCw5u6PEZHZcoHnUBlukZODHbm/wcL4Uu91fkn5jVo5cXXZcvs4VCkArVGrEj/52eUgTZCmOBGWQ==",
-          "requires": {
-            "base64-js": "^1.3.0",
-            "bech32": "^1.1.4",
-            "readonly-date": "^1.0.0"
-          }
-        },
-        "@cosmjs/math": {
-          "version": "0.29.5",
-          "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.29.5.tgz",
-          "integrity": "sha512-2GjKcv+A9f86MAWYLUkjhw1/WpRl2R1BTb3m9qPG7lzMA7ioYff9jY5SPCfafKdxM4TIQGxXQlYGewQL16O68Q==",
-          "requires": {
-            "bn.js": "^5.2.0"
-          }
-        },
-        "@cosmjs/utils": {
-          "version": "0.29.5",
-          "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.29.5.tgz",
-          "integrity": "sha512-m7h+RXDUxOzEOGt4P+3OVPX7PuakZT3GBmaM/Y2u+abN3xZkziykD/NvedYFvvCCdQo714XcGl33bwifS9FZPQ=="
-        }
       }
     },
     "@cosmjs/stream": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.29.5.tgz",
-      "integrity": "sha512-TToTDWyH1p05GBtF0Y8jFw2C+4783ueDCmDyxOMM6EU82IqpmIbfwcdMOCAm0JhnyMh+ocdebbFvnX/sGKzRAA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.30.0.tgz",
+      "integrity": "sha512-MkspvIDkZGZQcT8AOkCbG3vXzYED5jLJlki+FuNDWGOVCZVv89IF/v59f+Hg5pJUShRmGZ1cWfmpzYkGHxdEog==",
       "requires": {
         "xstream": "^11.14.0"
       }
     },
     "@cosmjs/tendermint-rpc": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.29.5.tgz",
-      "integrity": "sha512-ar80twieuAxsy0x2za/aO3kBr2DFPAXDmk2ikDbmkda+qqfXgl35l9CVAAjKRqd9d+cRvbQyb5M4wy6XQpEV6w==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.30.0.tgz",
+      "integrity": "sha512-QpNXwxfCPTHXrfq/LzXvwRxDjTV0R16kPISJ00zu3zSTtANCnBMZiNNFszrCdZKw81fNKo8/Rf2T0gCNvWfGog==",
       "requires": {
-        "@cosmjs/crypto": "^0.29.5",
-        "@cosmjs/encoding": "^0.29.5",
-        "@cosmjs/json-rpc": "^0.29.5",
-        "@cosmjs/math": "^0.29.5",
-        "@cosmjs/socket": "^0.29.5",
-        "@cosmjs/stream": "^0.29.5",
-        "@cosmjs/utils": "^0.29.5",
+        "@cosmjs/crypto": "^0.30.0",
+        "@cosmjs/encoding": "^0.30.0",
+        "@cosmjs/json-rpc": "^0.30.0",
+        "@cosmjs/math": "^0.30.0",
+        "@cosmjs/socket": "^0.30.0",
+        "@cosmjs/stream": "^0.30.0",
+        "@cosmjs/utils": "^0.30.0",
         "axios": "^0.21.2",
         "readonly-date": "^1.0.0",
         "xstream": "^11.14.0"
       },
       "dependencies": {
-        "@cosmjs/crypto": {
-          "version": "0.29.5",
-          "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.29.5.tgz",
-          "integrity": "sha512-2bKkaLGictaNL0UipQCL6C1afaisv6k8Wr/GCLx9FqiyFkh9ZgRHDyetD64ZsjnWV/N/D44s/esI+k6oPREaiQ==",
-          "requires": {
-            "@cosmjs/encoding": "^0.29.5",
-            "@cosmjs/math": "^0.29.5",
-            "@cosmjs/utils": "^0.29.5",
-            "@noble/hashes": "^1",
-            "bn.js": "^5.2.0",
-            "elliptic": "^6.5.4",
-            "libsodium-wrappers": "^0.7.6"
-          }
-        },
-        "@cosmjs/encoding": {
-          "version": "0.29.5",
-          "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.29.5.tgz",
-          "integrity": "sha512-G4rGl/Jg4dMCw5u6PEZHZcoHnUBlukZODHbm/wcL4Uu91fkn5jVo5cXXZcvs4VCkArVGrEj/52eUgTZCmOBGWQ==",
-          "requires": {
-            "base64-js": "^1.3.0",
-            "bech32": "^1.1.4",
-            "readonly-date": "^1.0.0"
-          }
-        },
-        "@cosmjs/math": {
-          "version": "0.29.5",
-          "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.29.5.tgz",
-          "integrity": "sha512-2GjKcv+A9f86MAWYLUkjhw1/WpRl2R1BTb3m9qPG7lzMA7ioYff9jY5SPCfafKdxM4TIQGxXQlYGewQL16O68Q==",
-          "requires": {
-            "bn.js": "^5.2.0"
-          }
-        },
-        "@cosmjs/utils": {
-          "version": "0.29.5",
-          "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.29.5.tgz",
-          "integrity": "sha512-m7h+RXDUxOzEOGt4P+3OVPX7PuakZT3GBmaM/Y2u+abN3xZkziykD/NvedYFvvCCdQo714XcGl33bwifS9FZPQ=="
-        },
         "axios": {
           "version": "0.21.4",
           "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
@@ -20288,6 +20212,11 @@
           }
         }
       }
+    },
+    "@cosmjs/utils": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.30.0.tgz",
+      "integrity": "sha512-A0YaBUlAojyuygqXOjDZa6YT/NOeScq08CqMD5VfU0COlzJS2DKN0z0jfYDt3t3VEXT5ZV8OaLbN3jHah1cSlA=="
     },
     "@cosmwasm/ts-codegen": {
       "version": "0.21.1",
@@ -20598,10 +20527,11 @@
         "@babel/preset-env": "7.19.4",
         "@babel/preset-typescript": "^7.18.6",
         "@babel/runtime": "^7.19.4",
-        "@cosmjs/amino": "0.29.4",
-        "@cosmjs/proto-signing": "0.29.4",
-        "@cosmjs/stargate": "0.29.4",
-        "@cosmjs/tendermint-rpc": "^0.29.4",
+        "@cosmjs/amino": "0.30.0",
+        "@cosmjs/proto-signing": "0.30.0",
+        "@cosmjs/stargate": "0.30.0",
+        "@cosmjs/tendermint-rpc": "^0.30.0",
+        "@osmonauts/lcd": "^0.10.0",
         "@osmonauts/telescope": "^0.78.0",
         "@protobufs/cosmos": "^0.1.0",
         "@protobufs/cosmos_proto": "^0.0.10",
@@ -20622,78 +20552,10 @@
         "regenerator-runtime": "^0.13.7",
         "rimraf": "^3.0.2",
         "ts-jest": "^29.0.3",
+        "tsc-silent": "^1.2.2",
         "typescript": "^4.8.4"
       },
       "dependencies": {
-        "@cosmjs/amino": {
-          "version": "0.29.4",
-          "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.29.4.tgz",
-          "integrity": "sha512-FBjaJ4oUKFtH34O7XjUk370x8sF7EbXD29miXrm0Rl5GEtEORJgQwutXQllHo5gBkpOxC+ZQ40CibXhPzH7G7A==",
-          "requires": {
-            "@cosmjs/crypto": "^0.29.4",
-            "@cosmjs/encoding": "^0.29.4",
-            "@cosmjs/math": "^0.29.4",
-            "@cosmjs/utils": "^0.29.4"
-          }
-        },
-        "@cosmjs/crypto": {
-          "version": "0.29.5",
-          "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.29.5.tgz",
-          "integrity": "sha512-2bKkaLGictaNL0UipQCL6C1afaisv6k8Wr/GCLx9FqiyFkh9ZgRHDyetD64ZsjnWV/N/D44s/esI+k6oPREaiQ==",
-          "requires": {
-            "@cosmjs/encoding": "^0.29.5",
-            "@cosmjs/math": "^0.29.5",
-            "@cosmjs/utils": "^0.29.5",
-            "@noble/hashes": "^1",
-            "bn.js": "^5.2.0",
-            "elliptic": "^6.5.4",
-            "libsodium-wrappers": "^0.7.6"
-          }
-        },
-        "@cosmjs/encoding": {
-          "version": "0.29.5",
-          "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.29.5.tgz",
-          "integrity": "sha512-G4rGl/Jg4dMCw5u6PEZHZcoHnUBlukZODHbm/wcL4Uu91fkn5jVo5cXXZcvs4VCkArVGrEj/52eUgTZCmOBGWQ==",
-          "requires": {
-            "base64-js": "^1.3.0",
-            "bech32": "^1.1.4",
-            "readonly-date": "^1.0.0"
-          }
-        },
-        "@cosmjs/math": {
-          "version": "0.29.5",
-          "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.29.5.tgz",
-          "integrity": "sha512-2GjKcv+A9f86MAWYLUkjhw1/WpRl2R1BTb3m9qPG7lzMA7ioYff9jY5SPCfafKdxM4TIQGxXQlYGewQL16O68Q==",
-          "requires": {
-            "bn.js": "^5.2.0"
-          }
-        },
-        "@cosmjs/proto-signing": {
-          "version": "0.29.4",
-          "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.29.4.tgz",
-          "integrity": "sha512-GdLOhMd54LZgG+kHf7uAWGYDT628yVhXPMWaG/1i3f3Kq4VsZgFBwJhhziM5kWblmFjBOhooGRwLrBnOxMusCg==",
-          "requires": {
-            "@cosmjs/amino": "^0.29.4",
-            "@cosmjs/crypto": "^0.29.4",
-            "@cosmjs/encoding": "^0.29.4",
-            "@cosmjs/math": "^0.29.4",
-            "@cosmjs/utils": "^0.29.4",
-            "cosmjs-types": "^0.5.2",
-            "long": "^4.0.0"
-          },
-          "dependencies": {
-            "long": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-              "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-            }
-          }
-        },
-        "@cosmjs/utils": {
-          "version": "0.29.5",
-          "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.29.5.tgz",
-          "integrity": "sha512-m7h+RXDUxOzEOGt4P+3OVPX7PuakZT3GBmaM/Y2u+abN3xZkziykD/NvedYFvvCCdQo714XcGl33bwifS9FZPQ=="
-        },
         "@humanwhocodes/config-array": {
           "version": "0.10.7",
           "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.7.tgz",
@@ -22638,6 +22500,26 @@
         }
       }
     },
+    "@osmonauts/lcd": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@osmonauts/lcd/-/lcd-0.10.0.tgz",
+      "integrity": "sha512-PzmXk9x9MHyLn2fUztpAqWqvDmMiEJaQv/JcAoAOE8VdHrD9Hf/KWnE1RZtamuS2ngQRqvQPD0xotCGXW7eTxA==",
+      "requires": {
+        "@babel/runtime": "^7.19.0",
+        "axios": "0.27.2"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.27.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+          "requires": {
+            "follow-redirects": "^1.14.9",
+            "form-data": "^4.0.0"
+          }
+        }
+      }
+    },
     "@osmonauts/proto-parser": {
       "version": "0.33.0",
       "resolved": "https://registry.npmjs.org/@osmonauts/proto-parser/-/proto-parser-0.33.0.tgz",
@@ -24123,8 +24005,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -24821,7 +24702,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -25037,9 +24917,9 @@
       }
     },
     "cosmjs-types": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.5.2.tgz",
-      "integrity": "sha512-zxCtIJj8v3Di7s39uN4LNcN3HIE1z0B9Z0SPE8ZNQR0oSzsuSe1ACgxoFkvhkS7WBasCAFcglS11G2hyfd5tPg==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.7.1.tgz",
+      "integrity": "sha512-qP89SGwi6YpvMTrM9CPzTfZ0JPNlXzgimqMLsa/ZjzW+L6MC8TCr6XmoWtFOT6GSfefvJLwFWq7YCtL456Bdzg==",
       "requires": {
         "long": "^4.0.0",
         "protobufjs": "~6.11.2"
@@ -25256,8 +25136,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "delegates": {
       "version": "1.0.0",
@@ -26272,7 +26151,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -28650,16 +28528,16 @@
       }
     },
     "libsodium": {
-      "version": "0.7.10",
-      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.10.tgz",
-      "integrity": "sha512-eY+z7hDrDKxkAK+QKZVNv92A5KYkxfvIshtBJkmg5TSiCnYqZP3i9OO9whE79Pwgm4jGaoHgkM4ao/b9Cyu4zQ=="
+      "version": "0.7.11",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.11.tgz",
+      "integrity": "sha512-WPfJ7sS53I2s4iM58QxY3Inb83/6mjlYgcmZs7DJsvDlnmVUwNinBCi5vBT43P6bHRy01O4zsMU2CoVR6xJ40A=="
     },
     "libsodium-wrappers": {
-      "version": "0.7.10",
-      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.10.tgz",
-      "integrity": "sha512-pO3F1Q9NPLB/MWIhehim42b/Fwb30JNScCNh8TcQ/kIc+qGLQch8ag8wb0keK3EP5kbGakk1H8Wwo7v+36rNQg==",
+      "version": "0.7.11",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.11.tgz",
+      "integrity": "sha512-SrcLtXj7BM19vUKtQuyQKiQCRJPgbpauzl3s0rSwD+60wtHqSUuqcoawlMDheCJga85nKOQwxNYQxf/CKAvs6Q==",
       "requires": {
-        "libsodium": "^0.7.0"
+        "libsodium": "^0.7.11"
       }
     },
     "lilconfig": {
@@ -29050,14 +28928,12 @@
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "requires": {
         "mime-db": "1.52.0"
       }
@@ -31049,6 +30925,12 @@
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true
     },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
     "resolve": {
       "version": "1.22.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -31872,6 +31754,118 @@
         }
       }
     },
+    "tsc-silent": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tsc-silent/-/tsc-silent-1.2.2.tgz",
+      "integrity": "sha512-XeNoMlREutyMotsQX7EijrgxXeyLscHUOV2W1goCZlEGvLH/7eFQ1snlPQf8cdQSdABqWEfvap0ab7s7FeCMrw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "10.12.7",
+        "yargs": "12 - 15"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.12.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.7.tgz",
+          "integrity": "sha512-Zh5Z4kACfbeE8aAOYh9mqotRxaZMro8MbBQtR8vEXOMiZo2rGEh2LayJijKdlu48YnS6y2EFU/oo2NCe5P6jGw==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "15.4.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "dev": true,
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
     "tsconfig-paths": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.1.2.tgz",
@@ -32446,6 +32440,12 @@
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
       }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
+      "dev": true
     },
     "which-typed-array": {
       "version": "1.1.9",

--- a/frontend/proof-of-existence/src/helpers/signing-client.ts
+++ b/frontend/proof-of-existence/src/helpers/signing-client.ts
@@ -1,0 +1,29 @@
+import type { GeneratedType, OfflineSigner } from "@cosmjs/proto-signing";
+import { SigningStargateClient, defaultRegistryTypes } from "@cosmjs/stargate";
+import { Tendermint37Client } from "@cosmjs/tendermint-rpc";
+import type { HttpEndpoint } from "@cosmjs/tendermint-rpc";
+import { getSigningEmpowerchainClientOptions } from "@empowerplastic/empowerchain-ts-client";
+
+export const getSigningEmpowerchainClient = async ({
+  rpcEndpoint,
+  signer,
+  defaultTypes = defaultRegistryTypes,
+}: {
+  rpcEndpoint: string | HttpEndpoint;
+  signer: OfflineSigner;
+  defaultTypes?: ReadonlyArray<[string, GeneratedType]>;
+}) => {
+  const { registry, aminoTypes } = getSigningEmpowerchainClientOptions({
+    defaultTypes,
+  });
+  const tm37Client = await Tendermint37Client.connect(rpcEndpoint);
+  const client = await SigningStargateClient.createWithSigner(
+    tm37Client,
+    signer,
+    {
+      registry,
+      aminoTypes,
+    }
+  );
+  return client;
+};

--- a/frontend/ts-client/package.json
+++ b/frontend/ts-client/package.json
@@ -81,10 +81,10 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.19.4",
-    "@cosmjs/amino": "0.29.4",
-    "@cosmjs/proto-signing": "0.29.4",
-    "@cosmjs/stargate": "0.29.4",
-    "@cosmjs/tendermint-rpc": "^0.29.4",
+    "@cosmjs/amino": "0.30.0",
+    "@cosmjs/proto-signing": "0.30.0",
+    "@cosmjs/stargate": "0.30.0",
+    "@cosmjs/tendermint-rpc": "^0.30.0",
     "@osmonauts/lcd": "^0.10.0",
     "protobufjs": "^6.11.2"
   }

--- a/frontend/ts-client/src/codegen/cosmos/rpc.query.ts
+++ b/frontend/ts-client/src/codegen/cosmos/rpc.query.ts
@@ -1,11 +1,11 @@
-import { Tendermint34Client, HttpEndpoint } from "@cosmjs/tendermint-rpc";
+import { Tendermint37Client, HttpEndpoint } from "@cosmjs/tendermint-rpc";
 import { QueryClient } from "@cosmjs/stargate";
 export const createRPCQueryClient = async ({
   rpcEndpoint
 }: {
   rpcEndpoint: string | HttpEndpoint;
 }) => {
-  const tmClient = await Tendermint34Client.connect(rpcEndpoint);
+  const tmClient = await Tendermint37Client.connect(rpcEndpoint);
   const client = new QueryClient(tmClient);
   return {
     cosmos: {

--- a/frontend/ts-client/src/codegen/empowerchain/rpc.query.ts
+++ b/frontend/ts-client/src/codegen/empowerchain/rpc.query.ts
@@ -1,11 +1,11 @@
-import { Tendermint34Client, HttpEndpoint } from "@cosmjs/tendermint-rpc";
+import { Tendermint37Client, HttpEndpoint } from "@cosmjs/tendermint-rpc";
 import { QueryClient } from "@cosmjs/stargate";
 export const createRPCQueryClient = async ({
   rpcEndpoint
 }: {
   rpcEndpoint: string | HttpEndpoint;
 }) => {
-  const tmClient = await Tendermint34Client.connect(rpcEndpoint);
+  const tmClient = await Tendermint37Client.connect(rpcEndpoint);
   const client = new QueryClient(tmClient);
   return {
     cosmos: {

--- a/frontend/ts-client/src/codegen/extern.ts
+++ b/frontend/ts-client/src/codegen/extern.ts
@@ -5,7 +5,7 @@
 */
 
 import { QueryClient, createProtobufRpcClient, ProtobufRpcClient } from '@cosmjs/stargate'
-import { Tendermint34Client, HttpEndpoint } from "@cosmjs/tendermint-rpc";
+import { Tendermint37Client, HttpEndpoint } from "@cosmjs/tendermint-rpc";
 
 const _rpcClients: Record<string, ProtobufRpcClient> = {};
 
@@ -24,7 +24,7 @@ export const getRpcClient = async (rpcEndpoint: string | HttpEndpoint) => {
     if (_rpcClients.hasOwnProperty(key)) {
         return _rpcClients[key];
     }
-    const tmClient = await Tendermint34Client.connect(rpcEndpoint);
+    const tmClient = await Tendermint37Client.connect(rpcEndpoint);
     //@ts-ignore
     const client = new QueryClient(tmClient);
     const rpc = createProtobufRpcClient(client);


### PR DESCRIPTION
Temporary util with Tendermint 0.37 client.

Instead of the client getter from ts-client, we should use the new one:

```ts
import { getSigningEmpowerchainClient } from "@/helpers/signing-client";

const client = getSigningEmpowerchainClient({
  rpcEndpoint: RPC_URL,
  signer: offlineSigner,
});
```