### PR TITLE
Fix link to EmpowerChain Release Page

### DIFF
--- a/docs/validators/full-node-setup.md
+++ b/docs/validators/full-node-setup.md
@@ -126,7 +126,7 @@ git clone https://github.com/EmpowerPlastic/empowerchain.git
 cd empowerchain
 ```
 
-Checkout the desired version to build. The latest release tag can be found on the [EmpowerChain](https://github.com/EmpowerPlastic/empowerchain/releases/) Release Page](https://github.com/EmpowerPlastic/empowerchain/releases/)
+Checkout the desired version to build. The latest release tag can be found on the [EmpowerChain Release Page](https://github.com/EmpowerPlastic/empowerchain/releases/)
 
 ```bash
 git checkout v0.0.3


### PR DESCRIPTION
Quick PR to fix the EmpowerChain Release Page link in the full-node-setup.md page. 

Issue:
![image](https://github.com/EmpowerPlastic/empowerchain/assets/96859270/07eb29ab-4c80-4858-8a91-5aaa218efbdc)
