### PR TITLE
Fix altrusitic-1/circulus-1 document references

### DIFF
--- a/docs/validators/cosmovisor-setup.md
+++ b/docs/validators/cosmovisor-setup.md
@@ -39,6 +39,8 @@ ln -s $HOME/.empowerd/cosmovisor/genesis/bin/empowerd $HOME/.empowerd/cosmovisor
 
 It is recommended to setup a systemd service to manage Cosmovisor. A full list of environment variables that may be used can be found in the [Cosmovisor docs](https://docs.cosmos.network/main/tooling/cosmovisor).
 
+> Note: If using `gvm` instead of a standard go installation, the path in the following ExecStart line may be different. To get cosmovisor's path while using `gvm`, ensure the `gvm` go profile that was used to build cosmovsior is active and run `$(which cosmovisor)`. This path should be using in place of `/home/<username>/go/bin/cosmovisor`.
+
 ```bash
 sudo tee /etc/systemd/system/empowerd.service > /dev/null <<EOF
 [Unit]
@@ -47,7 +49,7 @@ After=network-online.target
 
 [Service]
 User=<username>
-ExecStart=/home/<your-user>/go/bin/cosmovisor run start
+ExecStart=/home/<username>/go/bin/cosmovisor run start
 Restart=always
 RestartSec=3
 LimitNOFILE=4096

--- a/docs/validators/full-node-setup.md
+++ b/docs/validators/full-node-setup.md
@@ -154,10 +154,10 @@ Replace the `<chain-id>` field with the chain-id of the desired network.
 empowerd init "custom_moniker" --chain-id <chain-id>
 ```
 
-Example for the `altruistic-1` testnet:
+Example for the `circulus-1` testnet:
 
 ```bash
-empowerd init "custom_moniker" --chain-id altruistic-1
+empowerd init "custom_moniker" --chain-id circulus-1
 ```
 
 ### Retrieve the Genesis File
@@ -168,9 +168,9 @@ Retrieve a copy of the genesis file for the desired chain. The genesis file defi
 wget -O $HOME/empowerchain/config/genesis.json <genesis-url>
 ```
 
-Example for the `altruistic-1` testnet:
+Example for the `circulus-1` testnet:
 ```bash
-wget -O $HOME/empowerchain/config/genesis.json https://github.com/EmpowerPlastic/empowerchain/blob/main/testnets/altruistic-1/genesis.json
+wget -O $HOME/empowerchain/config/genesis.json https://github.com/EmpowerPlastic/empowerchain/blob/main/testnets/circulus-1/genesis.json
 ```
 
 ### Set Persistent Peers and Seeds

--- a/docs/validators/full-node-setup.md
+++ b/docs/validators/full-node-setup.md
@@ -51,19 +51,19 @@ chmod +x gvm-installer
 ./gvm-installer
 ```
 
-Since Empowerchain requires a modern version of `go`, version 1.4 is needed to compile later versions of `go` through `gvm`. Install `go1.4` and set the `GOROOT_BOOTSTRAP` value to the `$GOROOT` to configure this.
+Since Empowerchain requires a modern version of `go`, version 1.4 is needed to compile later versions of `go` through `gvm`. Starting at `go1.20` and above, `gvm` has issues compiling when using `go1.4`, so it is recommended to use the binary download of `go1.19` and compile `go1.20`+ with that. Install `go1.19` and set the `GOROOT_BOOTSTRAP` value to the `$GOROOT` to configure this.
 
 ```bash
-gvm install go1.4 -B
-gvm use go1.4
+gvm install go1.19 -B
+gvm use go1.19
 export GOROOT_BOOTSTRAP=$GOROOT
 ```
 
-Once `go1.4` is installed, `go1.20.3` can be installed through `gvm`.
+Once `go1.19` is installed, other version of go can be compiled. `go1.20.3` can be installed through `gvm`.
 
 ```bash
 gvm install go1.20.3
-gvm use go1.20.3
+gvm use go1.20.3 --default
 ```
 
 Check to ensure that version `1.20.3` is being used as the system's default `go` version.


### PR DESCRIPTION
This PR changes all instances of `altruistic-1` to `circulus-1` in the validator docs. Additionally, it adds a note regarding the cosmovisor path if installed while using `gvm` to manage go version installations. `gvm` tends to install go binaries into version specific directories rather than the typical `/home/$USER/go/bin` directory.

Edit: I've also pushed a new commit to clarify an issue when building `go1.20.3`. It is unable to be compiled with `go1.4` despite what gvm's documentation says. `go1.19` compiled without issue based on `go1.4`, so it's likely a change with `go1.20` specifically. To deal with this, I've recommended just downloading the binary version of `go1.19` and compiling `go1.20.3` using that since it doesn't result in this issue. I've also appended the `--default` flag to the `gvm use` command at the end so that the user doesn't need to remember to change their go profile on login for future updates. 