### PR TITLE
Add Dockerfile installation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:latest
+
+RUN apt-get update && apt-get install -y curl git jq lz4 build-essential unzip
+
+ARG version="1.20.5"
+ENV PATH="/usr/local/go/bin:${PATH}"
+ENV GOPATH="${HOME}/go"
+
+WORKDIR /root
+
+RUN curl -L -# -O "https://golang.org/dl/go${version}.linux-amd64.tar.gz" \
+    && rm -rf /usr/local/go \
+    && tar -C /usr/local -xzf "go${version}.linux-amd64.tar.gz" \
+    && rm "go${version}.linux-amd64.tar.gz"
+
+RUN touch ${HOME}/.bash_profile \
+    && echo "export PATH=\$PATH:/usr/local/go/bin:\$HOME/go/bin" >> ${HOME}/.bash_profile \
+    && echo "export GOPATH=\$HOME/go" >> ${HOME}/.bash_profile
+
+ENV PATH="${PATH}:${GOPATH}/bin"
+
+RUN . ${HOME}/.bash_profile
+
+RUN rm -rf empowerchain \
+    && git clone https://github.com/EmpowerPlastic/empowerchain \
+    && cd empowerchain/chain \
+    && git checkout v1.0.0-rc3 \
+    && make install
+
+COPY empower-setup.sh /root/empower-setup.sh
+RUN chmod +x /root/empower-setup.sh
+CMD ["/bin/bash", "/root/empower-setup.sh"]

--- a/docker/empower-setup.sh
+++ b/docker/empower-setup.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+read -p "Enter the NODE MONIKER: " NODE_MONIKER
+
+empowerd init "$NODE_MONIKER" --chain-id circulus-1
+
+seeds="d6a7cd9fa2bafc0087cb606de1d6d71216695c25@51.159.161.174:26656"
+peers="e8b3fa38a15c426e046dd42a41b8df65047e03d5@95.217.144.107:26656,89ea54a37cd5a641e44e0cee8426b8cc2c8e5dfb@51.159.141.221:26656,0747860035271d8f088106814a4d0781eb7b2bc7@142.132.203.60:27656,3c758d8e37748dc692621a0d59b454bacb69b501@65.108.224.156:26656,41b97fced48681273001692d3601cd4024ceba59@5.9.147.185:26656"
+
+sed -i -e 's|^seeds *=.*|seeds = "'$seeds'"|; s|^persistent_peers *=.*|persistent_peers = "'$peers'"|' $HOME/.empowerchain/config/config.toml
+sed -i.bak -e "s/^minimum-gas-prices *=.*/minimum-gas-prices = \"0.025umpwr\"/" $HOME/.empowerchain/config/app.toml
+
+sudo tee /etc/systemd/system/empowerd.service > /dev/null << EOF
+[Unit]
+Description=Empower Node
+After=network-online.target
+[Service]
+User=$USER
+ExecStart=$(which empowerd) start
+Restart=on-failure
+RestartSec=10
+LimitNOFILE=10000
+[Install]
+WantedBy=multi-user.target
+EOF
+
+empowerd tendermint unsafe-reset-all --home $HOME/.empowerchain --keep-addr-book
+
+sudo systemctl daemon-reload
+sudo systemctl enable empowerd
+sudo systemctl start empowerd
+
+sudo journalctl -u empowerd -f --no-hostname -o cat


### PR DESCRIPTION
Open a terminal and navigate to the directory containing the Dockerfile.

Build the Docker image by running the following command:

docker build -t empowerchain:latest .

Once the image is built, you can start a container based on the image using the following command:

arduino

docker run -it empowerchain:latest

The container will start, and the empower-setup.sh script will be executed inside the container. Follow the prompts to enter the NODE MONIKER and complete the setup process.

After the setup is finished, the container will continue running and display the output of the journalctl command for empowerd.