### PR TITLE
Don't save duplicate metadata uris

### DIFF
--- a/chain/x/plasticcredit/keeper/credit.go
+++ b/chain/x/plasticcredit/keeper/credit.go
@@ -11,6 +11,7 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/cosmos/gogoproto/proto"
+	"golang.org/x/exp/slices"
 
 	"github.com/EmpowerPlastic/empowerchain/utils"
 	"github.com/EmpowerPlastic/empowerchain/x/certificates"
@@ -278,8 +279,12 @@ func (k Keeper) issueCredits(ctx sdk.Context, creator string, projectID uint64, 
 	} else {
 		// If collection already exists, add new credits to the total and append new data if present
 		creditCollection.TotalAmount.Active += amount
-		creditCollection.MetadataUris = append(creditCollection.MetadataUris, metadataUris...)
-
+		// avoid adding duplicate metadata uris
+		for _, uri := range metadataUris {
+			if !slices.Contains(creditCollection.MetadataUris, uri) {
+				creditCollection.MetadataUris = append(creditCollection.MetadataUris, uri)
+			}
+		}
 	}
 
 	err = k.setCreditCollection(ctx, creditCollection)

--- a/chain/x/plasticcredit/keeper/msg_server_test.go
+++ b/chain/x/plasticcredit/keeper/msg_server_test.go
@@ -1264,6 +1264,7 @@ func (s *TestSuite) TestIssueCredits() {
 				s.Require().Equal(uint64(0), resp.Collection.TotalAmount.Retired)
 				s.Require().Equal(uint64(0), creditCollection.TotalAmount.Retired)
 				s.Require().Equal(uint64(0), ownerBalance.Balance.Retired)
+				s.Require().Equal(tc.msg.MetadataUris, creditCollection.MetadataUris)
 				s.Require().Len(events, 1)
 				parsedEvent, err := sdk.ParseTypedEvent(events[0])
 				s.Require().NoError(err)


### PR DESCRIPTION
Smol QOL improvement, so we don't have to watch out in our other internal tools to not add the same ipfs uri twice.