### PR TITLE
fix(marketplace): Dont cancel repeater if backend timeout or do somet…

### DIFF
--- a/frontend/marketplace/src/pages/AuctionPaymentSuccessful.vue
+++ b/frontend/marketplace/src/pages/AuctionPaymentSuccessful.vue
@@ -46,7 +46,10 @@ const handleFetchResponse = async (response: Response | null) => {
 const checkAuctionStatus = async () => {
   const { getAccessToken } = useAuth();
   const accessToken = await getAccessToken(PC_BACKEND_ENDPOINT);
-
+  const paymentId = route.query.paymentId as string;
+  if (!paymentId) {
+    throw new Error("Payment ID is missing");
+  }
   isCheckingStatus.value = true;
   try {
     await fetchRepeater(

--- a/frontend/marketplace/src/utils/fetchRepeater.ts
+++ b/frontend/marketplace/src/utils/fetchRepeater.ts
@@ -21,10 +21,18 @@ export async function fetchRepeater(
 
   while (attempts < maxAttempts) {
     attempts++;
-    response = await getRequest(url, { ...(options ?? {}), signal });
-    if (!(await shouldTryAgain(response))) {
-      break;
+    try {
+      response = await getRequest(url, { ...(options ?? {}), signal });
+      if (!(await shouldTryAgain(response))) {
+        break;
+      }
+    } catch (error) {
+      console.log("fetchRepeater Error", error);
+      if (attempts === maxAttempts) {
+        throw error;
+      }
     }
+
     await new Promise((resolve) => setTimeout(resolve, timeout));
     if (!signal.aborted) {
       controller.abort("Timeout");


### PR DESCRIPTION
…hing else that throw

Before PR: If backend timeout, the fetchRepeater will stop because it will throw.
After PR: If backend timeout, the fetchRepeater will catch the error and log it in the console and do another fetch attempt. If all attempts fail it will throw on the last attempt.